### PR TITLE
Automatically document nested ModelType fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.2
+
+* Ensure we automatically document ModelType fields nested in ListType and DictType fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 * Ensure we automatically document ModelType fields nested in ListType and DictType fields
 * Only document each model class once
+* All field and metadata output is now sorted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # 0.1.2
 
 * Ensure we automatically document ModelType fields nested in ListType and DictType fields
+* Only document each model class once

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # sphinx-autoschematics
 
+![Build Status](https://img.shields.io/travis/NerdWalletOSS/sphinx-autoschematics.svg)
+![CodeCov](https://img.shields.io/codecov/c/github/NerdWalletOSS/sphinx-autoschematics.svg)
+![PyPI - Version](https://img.shields.io/pypi/v/sphinx-autoschematics.svg)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sphinx-autoschematics.svg)
+
 This is a Sphinx extension to automatically document [Schematics](https://schematics.readthedocs.io/) models.
 
 ## How to use it

--- a/autoschematics/automodel.py
+++ b/autoschematics/automodel.py
@@ -50,7 +50,13 @@ class SchematicsModelDocumenter(ClassDocumenter):
 
         sourcename = self.get_sourcename()
 
+        seen_models = []
+
         def add_model_type(member):
+            if member.model_class in seen_models:
+                return
+            seen_models.append(member.model_class)
+
             self.add_line("", sourcename)
             self.add_line("| ", sourcename)
             self.add_line("| ", sourcename)

--- a/autoschematics/automodel.py
+++ b/autoschematics/automodel.py
@@ -146,7 +146,9 @@ class SchematicsTypeDocumenter(AttributeDocumenter):
                 return ", ".join(val)
 
             if isinstance(val, dict):
-                return ", ".join("{}={}".format(dk, val[dk]) for dk in sorted(val.keys()))
+                return ", ".join(
+                    "{}={}".format(dk, val[dk]) for dk in sorted(val.keys())
+                )
 
             return val
 
@@ -170,7 +172,9 @@ class SchematicsTypeDocumenter(AttributeDocumenter):
             if key == "description":
                 continue
             self.add_line(
-                "| **{}**: {}".format(humanize(key), format_val(self.object.metadata[key])),
+                "| **{}**: {}".format(
+                    humanize(key), format_val(self.object.metadata[key])
+                ),
                 sourcename,
             )
 

--- a/autoschematics/automodel.py
+++ b/autoschematics/automodel.py
@@ -141,6 +141,15 @@ class SchematicsTypeDocumenter(AttributeDocumenter):
                 return "1"
             return val
 
+        def format_val(val):
+            if isinstance(val, (list, tuple)):
+                return ", ".join(val)
+
+            if isinstance(val, dict):
+                return ", ".join("{}={}".format(dk, val[dk]) for dk in sorted(val.keys()))
+
+            return val
+
         for k in sorted(self.object.__dict__.keys(), key=field_sort):
             v = self.object.__dict__[k]
             if k == "_default":
@@ -155,19 +164,13 @@ class SchematicsTypeDocumenter(AttributeDocumenter):
             if isinstance(v, (list, tuple, dict)) and len(v) == 0:
                 continue
 
-            if isinstance(v, (list, tuple)):
-                v = ", ".join(v)
+            self.add_line("| **{}**: {}".format(humanize(k), format_val(v)), sourcename)
 
-            if isinstance(v, dict):
-                v = ", ".join("{}={}".format(dk, dv) for dk, dv in v.items())
-
-            self.add_line("| **{}**: {}".format(humanize(k), v), sourcename)
-
-        for key in self.object.metadata:
+        for key in sorted(self.object.metadata.keys()):
             if key == "description":
                 continue
             self.add_line(
-                "| **{}**: {}".format(humanize(key), self.object.metadata[key]),
+                "| **{}**: {}".format(humanize(key), format_val(self.object.metadata[key])),
                 sourcename,
             )
 

--- a/autoschematics/automodel.py
+++ b/autoschematics/automodel.py
@@ -97,10 +97,7 @@ class SchematicsTypeDocumenter(AttributeDocumenter):
 
     def add_model_line(self, sourcename, model_class):
         self.add_line(
-            "See :py:class:`{}`".format(
-                full_model_class_name(model_class)
-            ),
-            sourcename,
+            "See :py:class:`{}`".format(full_model_class_name(model_class)), sourcename,
         )
         self.add_line("", sourcename)
 

--- a/autoschematics/automodel.py
+++ b/autoschematics/automodel.py
@@ -135,18 +135,18 @@ class SchematicsTypeDocumenter(AttributeDocumenter):
 
         def field_sort(val):
             """Custom sort key that makes required first, default second and everything else sorted by value"""
-            if val == 'required':
-                return '0'
-            if val == '_default':
-                return '1'
+            if val == "required":
+                return "0"
+            if val == "_default":
+                return "1"
             return val
 
         for k in sorted(self.object.__dict__.keys(), key=field_sort):
             v = self.object.__dict__[k]
-            if k == '_default':
-                k = 'default'
+            if k == "_default":
+                k = "default"
 
-            if k[0] == '_' or k in fields_to_ignore:
+            if k[0] == "_" or k in fields_to_ignore:
                 continue
 
             if v is None:

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -71,9 +71,9 @@ def test_documenters(app):
         
         Required: True
         
-        Choices: fizz, buzz
-        
         Default: Undefined
+        
+        Choices: fizz, buzz
         
         Custom value: True
         

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -43,100 +43,101 @@ def test_documenters(app):
     expected = textwrap.dedent(
         """
     
-    class models.ExampleModel
-    
-    ExampleModel is a model for testing
-    
-    Just like in Sphinx .rst files you can use restructured text directives in the
-    docstring to provide rich content in the generated docs.
-    
-    foo: Foo
-    bar:
-      - bar1
-      - bar2
-      
-      
-      
-    bar ListType(StringType())
-    
-    Required: False
-    
-    Default: Undefined
-    
-    
-    
-    foo StringType()
-    
-    Required: True
-    
-    Default: Undefined
-    
-    Custom value: True
-    
-    
-    
-    sub1 ModelType(SubModel1)
-    
-    See models.SubModel1
-    
-    Required: False
-    
-    Default: Undefined
-    
-    
-    
-    sub1a ModelType(SubModel1)
-    
-    See models.SubModel1
-    
-    Required: False
-    
-    Default: Undefined
-    
-    
-    
-    sub2 ListType(ModelType(SubModel2))
-    
-    See models.SubModel2
-    
-    Required: False
-    
-    Default: Undefined
-    
-    
-    
-    
-    
-    
-    
-    class models.SubModel1
-    
-    This is SubModel1
-    
-    
-    
-    name StringType()
-    
-    Required: False
-    
-    Default: Undefined
-    
-    
-    
-    
-    
-    
-    
-    class models.SubModel2
-    
-    This is SubModel2
-    
-    
-    
-    name StringType()
-    
-    Required: False
-    
-    Default: Undefined"""
+        class models.ExampleModel
+        
+        ExampleModel is a model for testing
+        
+        Just like in Sphinx .rst files you can use restructured text directives in the
+        docstring to provide rich content in the generated docs.
+        
+        foo: Foo
+        bar:
+          - bar1
+          - bar2
+          
+          
+          
+        bar ListType(StringType())
+        
+        Required: False
+        
+        Default: Undefined
+        
+        
+        
+        foo StringType()
+        
+        Required: True
+        
+        Default: Undefined
+        
+        Custom value: True
+        
+        
+        
+        sub1 ModelType(SubModel1)
+        
+        See models.SubModel1
+        
+        Required: False
+        
+        Default: Undefined
+        
+        
+        
+        sub1a ModelType(SubModel1)
+        
+        See models.SubModel1
+        
+        Required: False
+        
+        Default: Undefined
+        
+        
+        
+        sub2 ListType(ModelType(SubModel2))
+        
+        See models.SubModel2
+        
+        Required: False
+        
+        Default: Undefined
+        
+        
+        
+        
+        
+        
+        
+        class models.SubModel1
+        
+        This is SubModel1
+        
+        
+        
+        name StringType()
+        
+        Required: False
+        
+        Default: Undefined
+        
+        
+        
+        
+        
+        
+        
+        class models.SubModel2
+        
+        This is SubModel2
+        
+        
+        
+        name StringType()
+        
+        Required: False
+        
+        Default: Undefined
+        """.rstrip()
     )
     assert content.astext() == expected

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -84,6 +84,16 @@ def test_documenters(app):
     
     
     
+    sub1a ModelType(SubModel1)
+    
+    See models.SubModel1
+    
+    Required: False
+    
+    Default: Undefined
+    
+    
+    
     sub2 ListType(ModelType(SubModel2))
     
     See models.SubModel2

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -40,7 +40,8 @@ def rootdir():
 def test_documenters(app):
     app.build()
     content = app.env.get_doctree("index")
-    expected = textwrap.dedent("""
+    expected = textwrap.dedent(
+        """
     
     class models.ExampleModel
     
@@ -136,5 +137,6 @@ def test_documenters(app):
     
     Required: False
     
-    Default: Undefined""")
+    Default: Undefined"""
+    )
     assert content.astext() == expected

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -41,7 +41,7 @@ def test_documenters(app):
     app.build()
     content = app.env.get_doctree("index")
     expected = textwrap.dedent(
-        """
+        u"""
     
         class models.ExampleModel
         
@@ -59,6 +59,8 @@ def test_documenters(app):
           
         bar ListType(StringType())
         
+        This is bar’s docstring
+        
         Required: False
         
         Default: Undefined
@@ -69,6 +71,8 @@ def test_documenters(app):
         
         Required: True
         
+        Choices: fizz, buzz
+        
         Default: Undefined
         
         Custom value: True
@@ -78,6 +82,8 @@ def test_documenters(app):
         sub1 ModelType(SubModel1)
         
         See models.SubModel1
+        
+        This is sub1’s docstring
         
         Required: False
         
@@ -111,7 +117,7 @@ def test_documenters(app):
         
         class models.SubModel1
         
-        This is SubModel1
+        This is SubModel1’s docstring
         
         
         
@@ -129,7 +135,7 @@ def test_documenters(app):
         
         class models.SubModel2
         
-        This is SubModel2
+        This is SubModel2’s docstring
         
         
         

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -75,6 +75,8 @@ def test_documenters(app):
         
         Choices: fizz, buzz
         
+        Another value: apple=3, one=1, two=2
+        
         Custom value: True
         
         

--- a/autoschematics/automodel_test.py
+++ b/autoschematics/automodel_test.py
@@ -1,6 +1,7 @@
 # coding=utf8
 
 import pytest
+import textwrap
 
 from schematics.types import StringType
 from schematics.types.compound import ListType
@@ -39,5 +40,91 @@ def rootdir():
 def test_documenters(app):
     app.build()
     content = app.env.get_doctree("index")
-    expected = u"\n\nclass models.ExampleModel\n\nExampleModel is a model for testing\n\nJust like in Sphinx .rst files you can use restructured text directives in the\ndocstring to provide rich content in the generated docs.\n\nfoo: Foo\nbar:\n  - bar1\n  - bar2\n\n\n\nbar ListType(StringType())\n\nRequired: False\n\nDefault: Undefined\n\n\n\nfoo StringType()\n\nRequired: True\n\nDefault: Undefined\n\nCustom value: True"  # noqa
+    expected = textwrap.dedent("""
+    
+    class models.ExampleModel
+    
+    ExampleModel is a model for testing
+    
+    Just like in Sphinx .rst files you can use restructured text directives in the
+    docstring to provide rich content in the generated docs.
+    
+    foo: Foo
+    bar:
+      - bar1
+      - bar2
+      
+      
+      
+    bar ListType(StringType())
+    
+    Required: False
+    
+    Default: Undefined
+    
+    
+    
+    foo StringType()
+    
+    Required: True
+    
+    Default: Undefined
+    
+    Custom value: True
+    
+    
+    
+    sub1 ModelType(SubModel1)
+    
+    See models.SubModel1
+    
+    Required: False
+    
+    Default: Undefined
+    
+    
+    
+    sub2 ListType(ModelType(SubModel2))
+    
+    See models.SubModel2
+    
+    Required: False
+    
+    Default: Undefined
+    
+    
+    
+    
+    
+    
+    
+    class models.SubModel1
+    
+    This is SubModel1
+    
+    
+    
+    name StringType()
+    
+    Required: False
+    
+    Default: Undefined
+    
+    
+    
+    
+    
+    
+    
+    class models.SubModel2
+    
+    This is SubModel2
+    
+    
+    
+    name StringType()
+    
+    Required: False
+    
+    Default: Undefined""")
     assert content.astext() == expected

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_fd:
 
 setup(
     name="sphinx-autoschematics",
-    version="0.1.1",
+    version="0.1.2",
     description="sphinx-autoschematics provides sphinx extenions for documenting schematics models",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -33,4 +33,6 @@ class ExampleModel(Model):
 
     sub1 = ModelType(SubModel1)
 
+    sub1a = ModelType(SubModel1)
+
     sub2 = ListType(ModelType(SubModel2))

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -4,13 +4,13 @@ from schematics.models import Model
 
 
 class SubModel1(Model):
-    """This is SubModel1"""
+    """This is SubModel1's docstring"""
 
     name = StringType()
 
 
 class SubModel2(Model):
-    """This is SubModel2"""
+    """This is SubModel2's docstring"""
 
     name = StringType()
 
@@ -29,12 +29,16 @@ class ExampleModel(Model):
           - bar2
     """
 
-    foo = StringType(required=True, metadata=dict(custom_value=True))
+    foo = StringType(required=True, metadata=dict(custom_value=True), choices=("fizz", "buzz"))
 
+    #: This is bar's docstring
     bar = ListType(StringType)
 
-    sub1 = ModelType(SubModel1)
+    sub1 = ModelType(SubModel1, metadata=dict(description="This is sub1's docstring"))
 
     sub1a = ModelType(SubModel1)
 
     sub2 = ListType(ModelType(SubModel2))
+
+    #: Secret will not be documented
+    secret = StringType(metadata=dict(document=False))

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -30,7 +30,9 @@ class ExampleModel(Model):
     """
 
     foo = StringType(
-        required=True, metadata=dict(custom_value=True), choices=("fizz", "buzz")
+        required=True,
+        metadata=dict(custom_value=True, another_value=dict(one="1", two="2", apple="3")),
+        choices=("fizz", "buzz"),
     )
 
     #: This is bar's docstring

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -5,11 +5,13 @@ from schematics.models import Model
 
 class SubModel1(Model):
     """This is SubModel1"""
+
     name = StringType()
 
 
 class SubModel2(Model):
     """This is SubModel2"""
+
     name = StringType()
 
 

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -31,7 +31,9 @@ class ExampleModel(Model):
 
     foo = StringType(
         required=True,
-        metadata=dict(custom_value=True, another_value=dict(one="1", two="2", apple="3")),
+        metadata=dict(
+            custom_value=True, another_value=dict(one="1", two="2", apple="3")
+        ),
         choices=("fizz", "buzz"),
     )
 

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -1,6 +1,16 @@
 from schematics.types import StringType
-from schematics.types.compound import ListType
+from schematics.types.compound import ListType, ModelType
 from schematics.models import Model
+
+
+class SubModel1(Model):
+    """This is SubModel1"""
+    name = StringType()
+
+
+class SubModel2(Model):
+    """This is SubModel2"""
+    name = StringType()
 
 
 class ExampleModel(Model):
@@ -20,3 +30,7 @@ class ExampleModel(Model):
     foo = StringType(required=True, metadata=dict(custom_value=True))
 
     bar = ListType(StringType)
+
+    sub1 = ModelType(SubModel1)
+
+    sub2 = ListType(ModelType(SubModel2))

--- a/test-root/models.py
+++ b/test-root/models.py
@@ -29,7 +29,9 @@ class ExampleModel(Model):
           - bar2
     """
 
-    foo = StringType(required=True, metadata=dict(custom_value=True), choices=("fizz", "buzz"))
+    foo = StringType(
+        required=True, metadata=dict(custom_value=True), choices=("fizz", "buzz")
+    )
 
     #: This is bar's docstring
     bar = ListType(StringType)


### PR DESCRIPTION
This PR adds support to automatically document `ModelType` fields that are nested inside of `ListType` and `DictType` fields.

Previously we only automatically documented top-level `ModelType` fields.

FYI @KennyRozario